### PR TITLE
Allow cooler files input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # SELFISH
-SELFISH (Discovery of Differential Chromatin Interactions via a Self-Similarity Measure) is a tool by Abbas Roayaei Ardakany, Ferhat Ay, and Stefano Lonardi. It is currently maintained by Tuvan Gezer (hgezer@lji.org).  
+SELFISH (Discovery of Differential Chromatin Interactions via a Self-Similarity Measure) is a tool by Abbas Roayaei Ardakany, Ferhat Ay, and Stefano Lonardi. It is currently maintained by Tuvan Gezer (hgezer@lji.org).
 SELFISH is a tool for finding differential chromatin interactions
-between two Hi-C contact maps. It uses self-similarity to model interactions 
-in a robust way. For more information read the full 
-paper: <a href="https://www.biorxiv.org/content/10.1101/540708v1?rss=1" target="_blank">**Selfish: Discovery of Differential Chromatin Interactions via a Self-Similarity Measure**</a>. 
+between two Hi-C contact maps. It uses self-similarity to model interactions
+in a robust way. For more information read the full
+paper: <a href="https://www.biorxiv.org/content/10.1101/540708v1?rss=1" target="_blank">**Selfish: Discovery of Differential Chromatin Interactions via a Self-Similarity Measure**</a>.
 ![DCI](/demo.png)
 ## Installation and usage
 ### PIP
@@ -25,7 +25,7 @@ git clone https://github.com/ay-lab/selfish
 ```
 ### Nextflow
 If you have any problem regarding dependencies or version mismatches, we recommend using <a href="https://www.nextflow.io/" target="_blank">Nextflow</a> with a container technology like <a href="https://www.docker.com/get-started" target="_blank">Docker</a> or <a href="https://singularity.lbl.gov/" target="_blank">Singularity</a>. These methods require Nextflow(Can be installed with a single command that doesn't require special permissions.), and the desired container technology to be available.
-Program arguments are given to Nextflow with two dashes and the short format listed below.   
+Program arguments are given to Nextflow with two dashes and the short format listed below.
 **Updating:** If Nextflow warns that your project is outdated, use `nextflow pull ay-lab/selfish` in order to update to latest version.
 #### Install Nextflow
 Nextflow works for Linux and OS X. Install it using **one** of the commands listed below. **Requires Java 8+**
@@ -88,9 +88,9 @@ Selfish uses some python packages to accomplish its mission. These are the packa
 | **-V** | **--version** | Shows the version of the tool. |
 
 ### Input Formats
-SELFISH supports 3 different input formats. **Plain text**, **.hic**, **.bed/.matrix** pairs(HiC-Pro format).
+SELFISH supports 3 different input formats. **Plain text**, **.hic**, **.cool**, **.bed/.matrix** pairs (HiC-Pro format).
 #### Text Contact Maps
-Contact maps need to have the following format. They must not have a header. 
+Contact maps need to have the following format. They must not have a header.
 Values must be separated by either a space, a tab, or a comma.
 
 | Chromosome | Midpoint 1 | Chromosome | Midpoint 2 | Contact Count |
@@ -101,14 +101,18 @@ Values must be separated by either a space, a tab, or a comma.
 
 
 #### Bed-Matrix pairs (HiC-Pro format)
-**User must provide a chromosome with the -ch argument.**  
+**User must provide a chromosome with the -ch argument.**
 .bed and .matrix files must have the same name other than the extension.
  Either file name can be provided as an input for selfish and the program will search for the second file automatically.
- 
- 
+
+
 #### HiC file
-**User must provide a chromosome with the -ch argument.**  
+**User must provide a chromosome with the -ch argument.**
 Selfish uses juicer's *straw* tool to read .hic files.
+
+#### .cool file
+**User must provide a chromosome with the -ch argument.**
+Selfish uses *cooler* to read .cool files.
 
 #### Bias File
 Bias file need to have the following format.
@@ -122,9 +126,9 @@ Bias file must not have a header.
 | ... | ... | ... |
 
 ### Output
-Output of Selfish is a matrix of p-values indicating the probability of differential conformation (Smaller values mean more significant.). 
+Output of Selfish is a matrix of p-values indicating the probability of differential conformation (Smaller values mean more significant.).
 X and Y coordinates indicate the bin midpoints.
-File format of the output is a binary numpy file. It can be read by using Numpy as follows.  
+File format of the output is a binary numpy file. It can be read by using Numpy as follows.
 ```python
 import numpy as np
 matrix = np.load("/path/to/output/selfish.npy")

--- a/selfish/selfish.py
+++ b/selfish/selfish.py
@@ -312,7 +312,7 @@ def DCI(f1,
         elif f2.endswith('.mcool'): #cooler.fileops.is_multires_file(f1):
             b = readMultiCoolFile(f2, chromosome, res)
         else:
-            b = read_map_pd(f2, res, biasDict1, dt, chromosome)
+            b = read_map_pd(f2, res, biasDict2, dt, chromosome)
 
         f1 = f1.split('.')[0] if '.' in f1 else f1
         f2 = f2.split('.')[0] if '.' in f2 else f2

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     entry_points = {
         "console_scripts": ['selfish = selfish.selfish:main']
         },
-    python_requires = '~=3.6',
+    python_requires = '>=3.5',
     author = 'Ferhat Ay',
     author_email = 'ferhatay@lji.org',
     license = 'MIT',
@@ -30,7 +30,8 @@ setup(
         'seaborn',
         'statsmodels',
         'pathlib',
-        'hic-straw'
+        'hic-straw',
+        'cooler'
     ],
     classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Hi, wanted to try this tool and was easier to add support for cooler files than to save them in a different format :)

I also changed python version for 3.5 instead of 3.6 in setup.py, simply because I have 3.5 - and it seems to work on it fine too, but I can revert this.

Something I discovered is that the matrices can't have NaN values in them for selfish to work, so had to make them 0 for coolers, which is not great, since NaNs have a different meaning from just absence of measurements - they denote filtered out bins, and, for example, it's impossible to have a differential interaction between a filtered bin and non-filtered bin, in case this differs between conditions.