### PR TITLE
Fix bug that causes qvals and log foldchanges to decouple

### DIFF
--- a/selfish/selfish.py
+++ b/selfish/selfish.py
@@ -607,6 +607,7 @@ def DCI(f1,
         x = x[nonsparse]
         y = y[nonsparse]
         q_val= q_val[nonsparse]
+        changes_array = changes_array[nonsparse]
         diff = None
         print("number of differential interactions after sparsity check: ",len(x))
         return _, x, y, q_val, changes_array


### PR DESCRIPTION
When outputting a TSV file (i.e. by setting `-t` / `--tsvout`) there is [a sparsity check](https://github.com/ay-lab/selfish/blob/master/selfish/selfish.py#L583-L612) performed by default, as [`st` is set](https://github.com/ay-lab/selfish/blob/master/selfish/selfish.py#L66) even if not passed as an argument. However, after the check, only `q_val` is reindexed while `changes_array` retains the initial indexing. This results in a decorrelation between q-values and logfc values such that the change values no longer correspond to their significance values. In this pull request I reindex `changes_array` as well to maintain the correspondence.