### PR TITLE
Update selfish.py

### DIFF
--- a/selfish/selfish.py
+++ b/selfish/selfish.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy.stats import norm
 from scipy.ndimage import gaussian_filter
 import matplotlib.pyplot as plt
-import straw
+import hicstraw as straw
 import cooler
 import pandas as pd
 import statsmodels.stats.multitest as smm


### PR DESCRIPTION
When running SELFISH an error arises: `ModuleNotFoundError: No module named 'straw'`
I imagine because the module is `hicstraw`

So I changed with: `import hicstraw as straw`